### PR TITLE
outlook 단체계정을 불러오고자 발악했으나

### DIFF
--- a/mailmoajo2/app/src/main/java/com/melon/mailmoajo/fragment/SettingsFragment.kt
+++ b/mailmoajo2/app/src/main/java/com/melon/mailmoajo/fragment/SettingsFragment.kt
@@ -348,7 +348,7 @@ class SettingsFragment : Fragment() {
                     TAG,
                     authenticationResult.accessToken.toString()
                 )
-                Log.d(TAG, "ID Token: " + authenticationResult.account.claims!!["id_token"])
+                Log.d(TAG, "ID Token: " + authenticationResult.account.idToken)
 
                 /* Update account */mAccount = authenticationResult.account
 
@@ -384,7 +384,8 @@ class SettingsFragment : Fragment() {
             authenticationResult.accessToken,
             com.android.volley.Response.Listener<JSONObject> { response -> /* Successfully called graph, process data and send to UI */
                 Log.d(TAG, "Response: $response")
-
+                for (i:Int in 0 until response.length()){
+                }
 //                displayGraphResult(response)
             },
             com.android.volley.Response.ErrorListener { error ->

--- a/mailmoajo2/app/src/main/res/raw/msalconfiguration.json
+++ b/mailmoajo2/app/src/main/res/raw/msalconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "client_id" : "780effb6-b34b-4101-a0f2-8a6fd0be5198",
+  "client_id" : "3b61261d-3826-42a2-a76c-824e47957c4e",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.melon.mailmoajo/yG7xh%2BP47vHoeLFfL%2F%2F4ro3XLfc%3D",
   "account_mode" : "SINGLE",


### PR DESCRIPTION
기관이 아니면 안됨, 다른 보조방안을 강구해도 할 수 없음. 사업자 등록번호 등 인증된 단체만이 MPN ID를 부여받을 수 있으며 그것으로 verified 게시자를 게시할 수 있음. 강한 보안정책이 따르는 단체 계정들은 이 서비스를 사용할 수 없음....

outlook 메일 저장형식 맞추고
db저장 로직 구현, 메일함별로 나누는 로직 구현,
-타 사용자 로그인 시 데이터 처리
-테마 꾸미기

2020년 11월 9일부터 최종 사용자는 확인된 게시자 없이 새로 등록된 다중 테넌트 앱에 동의할 수 없습니다.